### PR TITLE
Light graphs to graphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.3.10"
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -16,9 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Distributions = "0.25"
-Graphs = "= 1.8"
 RecipesBase = "1"
-SimpleWeightedGraphs = "= 1.3"
 StaticArrays = "1.2"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.3.10"
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NWNTools"
 uuid = "57a86b13-246b-47ef-b5f2-61b58713240d"
 authors = ["Emma Johnson"]
-version = "0.3.10"
+version = "0.3.11"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.3.10"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -16,9 +16,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Distributions = "0.25"
-LightGraphs = "= 1.3.5"
+Graphs = "= 1.8"
 RecipesBase = "1"
-SimpleWeightedGraphs = "= 1.1.1"
+SimpleWeightedGraphs = "= 1.3"
 StaticArrays = "1.2"
 julia = "1"
 

--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -45,7 +45,7 @@ function each_intersect(f!, arr₁::Array{Line{S,N}}, arr₂::Array{Line{S,N}}, 
             ps = intersection_params(arr₁[i₁],arr₂[i₂])
             if (0.0 ≤ ps[1] ≤ 1.0) && (0.0 ≤ ps[2] ≤ 1.0)
                 p = line_segment_point(ps[1],arr₁[i₁])
-                if sum( zero(SVector{N, S}) .≤ p .≤ dims ) == N
+                if all( zero(SVector{N, S}) .≤ p .≤ dims )
                     f!(i₁,i₂,arr₁,arr₂,dims,ps,p,arg)
                 end
             end
@@ -71,7 +71,7 @@ function each_intersect(f!, arr::Array{Line{S,N}}, dims::SVector{N,S}, arg) wher
             ps = intersection_params(arr[i₁],arr[i₂])
             if (0.0 ≤ ps[1] ≤ 1.0) && (0.0 ≤ ps[2] ≤ 1.0)
                 p = line_segment_point(ps[1],arr[i₁])
-                if sum( zero(SVector{N, S}) .≤ p .≤ dims ) == N
+                if all( zero(SVector{N, S}) .≤ p .≤ dims )
                     f!(i₁,i₂,arr,dims,ps,p,arg)
                 end
             end

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,6 +1,6 @@
 export Line, Wire, StickNetwork, WireProp, NWN_circuit, len
 
-using StaticArrays, LinearAlgebra, LightGraphs, SimpleWeightedGraphs
+using StaticArrays, LinearAlgebra, Graphs, SimpleWeightedGraphs
 
 
 """


### PR DESCRIPTION
Have updated the references and project files to reflect the update to Graphs.jl from LightGraphs.jl. This has unpinned the version of SimpleWeightedGraphs.jl and will be added back to compat by the bot (hopefully). Also updated a few lines of code to use new Julia function `all` rather than previous jank. 